### PR TITLE
docs(security): add security policy

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -111,6 +111,10 @@ cd cello
 ### License
 Cello 使用 Apache 2.0 证书, 详情见 [LICENSE](./LICENSE)。
 
+## Security and privacy
+本项目高度重视安全问题。
+有关漏洞报告及受支持的版本，请参阅 [SECURITY.md](SECURITY.md)。
+
 
 [CNI]: https://www.cni.dev/
 [辅助ENI]: https://www.volcengine.com/docs/6401/68940#%E7%BD%91%E5%8D%A1

--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ If you have any questions or want to contribute, you are welcome to communicate 
 ### License
 Cello is under the Apache 2.0 license. See the [LICENSE](./LICENSE) file for details.
 
+## Security and privacy
+This project takes security seriously.
+For vulnerability reporting and supported versions, see [SECURITY.md](SECURITY.md)
+
 
 [CNI]: https://www.cni.dev/
 [secondary ENI]: https://www.volcengine.com/docs/6401/68940#%E7%BD%91%E5%8D%A1

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+## Security and privacy
+
+If you discover potential security issues in the project, or believe you may have found a security issue, please notify the ByteDance security team through our [security center](https://security.bytedance.com/src/) or [vulnerability reporting email](mailto:src@bytedance.com). Please do not create public GitHub Issues.
+
+We will assess the vulnerability based on the Common Vulnerability Scoring System (CVSS 3.1). The security team will keep you updated on key progress and may request further information or guidance from you. You are welcome to contact us via the email or website mentioned above to ask questions or discuss disclosure matters.
+
+To protect the security of our customers, ByteDance requests that you do not publish or share information regarding the vulnerability in any public forum, nor publish or share data involving users, until the vulnerability has been remediated and our users have been notified. Please understand that the time required for remediation depends on the severity of the vulnerability and the scope of the impact.
+
+Individuals, companies, and security teams may wish to publish security advisories on their own websites or other forums. Please contact us via the email or website mentioned above prior to publication to discuss the information that can be disclosed and to coordinate the disclosure timeline.
+
+## Bug Bounty Reward
+
+[For the policy of bug bounty reward](https://bytedance.larkoffice.com/docx/ZstQd7bbooDctqxBCAmcFasOngd), if you have any questions about the rules, please contact [https://src.bytedance.com/home](https://src.bytedance.com/home) for consultation.


### PR DESCRIPTION
Add SECURITY.md describing the vulnerability reporting process and bug bounty reward, and link it from both README.md and README-zh_CN.md.